### PR TITLE
"high-rewards" -> "high-reward"

### DIFF
--- a/01-algorithms/01-binary-search.md
+++ b/01-algorithms/01-binary-search.md
@@ -22,7 +22,7 @@ The same algorithm can be applied to the children game Guess Who?. The optimal
 strategy is to ask a question that will discard half of the options.
 
 If you go to the opposite extreme, and ask a very specific question, it is
-a high-risk, high-rewards scenario. It is very likely you have obtained little
+a high-risk, high-reward scenario. It is very likely you have obtained little
 information in most cases, but in a few you have guessed correctly.
 
 #### Properties


### PR DESCRIPTION
"High-risk, high-rewards" sounded awkward.
